### PR TITLE
TrainingProgram refactor and  added Employee Training controller (supports post and delete)

### DIFF
--- a/BangazonAPI/Controllers/EmployeeTrainingController.cs
+++ b/BangazonAPI/Controllers/EmployeeTrainingController.cs
@@ -1,0 +1,120 @@
+﻿using BangazonAPI.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BangazonAPI.Controllers
+
+
+
+{
+    [Route("api/[controller]")]
+[ApiController]
+public class EmployeeTrainingController : ControllerBase
+{
+
+    private readonly IConfiguration _config;
+    public EmployeeTrainingController(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public SqlConnection Connection
+    {
+        get
+        {
+            return new SqlConnection(_config.GetConnectionString("DefaultConnection"));
+        }
+    }
+
+
+
+        [HttpPost]
+        public async Task<IActionResult> Post([FromBody] EmployeeTraining EmployeeTraining)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = "INSERT INTO EmployeeTraining (EmployeeId, TrainingProgramId) OUTPUT INSERTED.Id VALUES (@EmployeeId, @TrainingProgramId)";
+
+                    cmd.Parameters.Add(new SqlParameter("@EmployeeId", EmployeeTraining.EmployeeId));
+                    cmd.Parameters.Add(new SqlParameter("@TrainingProgramId", EmployeeTraining.TrainingProgramId));
+
+                    int newId = (int)cmd.ExecuteScalar();
+                    EmployeeTraining.Id = newId;
+                    return CreatedAtRoute("GetTrainingProgram", new { id = newId }, EmployeeTraining);
+                }
+            }
+        }
+
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete([FromRoute] int id)
+        {
+            try
+            {
+                using (SqlConnection conn = Connection)
+                {
+                    conn.Open();
+                    using (SqlCommand cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = @"DELETE FROM EmployeeTraining WHERE ID = @id";
+                        cmd.Parameters.Add(new SqlParameter("@id", id));
+
+                        int rowsAffected = cmd.ExecuteNonQuery();
+                        if (rowsAffected > 0)
+                        {
+                            return new StatusCodeResult(StatusCodes.Status204NoContent);
+                        }
+                        throw new Exception("No rows affected");
+                    }
+                }
+
+            }
+            catch (Exception)
+
+            {
+                if (!ProgramExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+
+        private bool ProgramExists(int id)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT Id, EmployeeId, TrainingProgramId, FROM EmployeeTraining WHERE Id = @id";
+                    cmd.Parameters.Add(new SqlParameter("@id", id));
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    return reader.Read();
+
+                }
+            }
+        }
+
+    }
+
+}
+
+
+
+
+

--- a/BangazonAPI/Controllers/TrainingProgramController.cs
+++ b/BangazonAPI/Controllers/TrainingProgramController.cs
@@ -88,15 +88,23 @@ namespace BangazonAPI.Controllers
                             {
                                 if (trainingPrograms.Any(x => x.Id == trainingProgram.Id)) {
                                     {
-                                        TrainingProgram program = trainingPrograms.Where(x => x.Id ==       trainingProgram.Id).FirstOrDefault();
-                                        program.Employees.Add(employee);
+                                        TrainingProgram program = trainingPrograms.Where(x => x.Id ==           trainingProgram.Id).FirstOrDefault();
+
+                                        //Check to see if employee is null before adding
+                                        if (!reader.IsDBNull(reader.GetOrdinal("EmployeeId")))
+                                        {
+                                            program.Employees.Add(employee);
+                                        }
 
                                     } 
 
                                 }
                                 else
                                 {
-                                    trainingProgram.Employees.Add(employee);
+                                    //Check to see if employee is null before adding
+                                    if (!reader.IsDBNull(reader.GetOrdinal("EmployeeId")))
+                                    { trainingProgram.Employees.Add(employee); }
+
                                     trainingPrograms.Add(trainingProgram);
                                 }
                             }
@@ -107,11 +115,17 @@ namespace BangazonAPI.Controllers
                             {
 
                                 TrainingProgram program = trainingPrograms.Where(x => x.Id == trainingProgram.Id).FirstOrDefault();
-                                program.Employees.Add(employee);
+
+                                //Check to see if employee is null before adding
+                                if (!reader.IsDBNull(reader.GetOrdinal("EmployeeId")))
+                                { program.Employees.Add(employee); }
 
                             } else
                             {
-                                trainingProgram.Employees.Add(employee);
+                                //Check to see if employee is null before adding
+                                if (!reader.IsDBNull(reader.GetOrdinal("EmployeeId"))) { 
+                                    trainingProgram.Employees.Add(employee);
+                                }
                                 trainingPrograms.Add(trainingProgram);
                             }
                         }

--- a/BangazonAPI/Controllers/TrainingProgramController.cs
+++ b/BangazonAPI/Controllers/TrainingProgramController.cs
@@ -46,7 +46,7 @@ namespace BangazonAPI.Controllers
                     //SqlCommands dependant on query strings
 
 
-                    cmd.CommandText = @"SELECT tp.Id, tp.Name, tp.StartDate, tp.EndDate, tp.MaxAttendees, e.Id AS EmployeeId, e.FirstName, e.LastName, e.DepartmentId, e.IsSupervisor  FROM TrainingProgram tp JOIN EmployeeTraining et on tp.Id = et.TrainingProgramId JOIN Employee e on e.Id = et.EmployeeId";
+                    cmd.CommandText = @"SELECT tp.Id, tp.Name, tp.StartDate, tp.EndDate, tp.MaxAttendees, e.Id AS EmployeeId, e.FirstName, e.LastName, e.DepartmentId, e.IsSupervisor  FROM TrainingProgram tp LEFT JOIN EmployeeTraining et on tp.Id = et.TrainingProgramId LEFT JOIN Employee e on e.Id = et.EmployeeId";
 
 
 
@@ -64,8 +64,10 @@ namespace BangazonAPI.Controllers
                             MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees")),
                             Employees = new List<Employee>()
                         };
+                        Employee employee = null;
 
-                        Employee employee = new Employee
+                        if (!reader.IsDBNull(reader.GetOrdinal("EmployeeId"))) { 
+                        employee = new Employee
                         {
                             Id = reader.GetInt32(reader.GetOrdinal("EmployeeId")),
                             FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
@@ -73,6 +75,7 @@ namespace BangazonAPI.Controllers
                             DepartmentId = reader.GetInt32(reader.GetOrdinal("DepartmentId")),
                             IsSuperVisor = reader.GetBoolean(reader.GetOrdinal("IsSuperVisor"))
                         };
+                        }
 
 
                         DateTime now = DateTime.Now;
@@ -85,7 +88,7 @@ namespace BangazonAPI.Controllers
                             {
                                 if (trainingPrograms.Any(x => x.Id == trainingProgram.Id)) {
                                     {
-                                        TrainingProgram program = trainingPrograms.Where(x => x.Id == trainingProgram.Id).FirstOrDefault();
+                                        TrainingProgram program = trainingPrograms.Where(x => x.Id ==       trainingProgram.Id).FirstOrDefault();
                                         program.Employees.Add(employee);
 
                                     } 

--- a/BangazonAPI/Models/EmployeeTraining.cs
+++ b/BangazonAPI/Models/EmployeeTraining.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BangazonAPI.Models
+{
+    public class EmployeeTraining
+    {
+
+        public int Id { get; set; }
+        public int EmployeeId { get; set; }
+        public int TrainingProgramId { get; set; }
+    }
+}

--- a/BangazonAPI/Startup.cs
+++ b/BangazonAPI/Startup.cs
@@ -45,7 +45,7 @@ namespace BangazonAPI
             app.UseCors(builder =>
             {
                 //builder.WithOrigins("http://127.0.0.1:8080/");
-                builder.AllowAnyOrigin();
+                builder.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod();
                 
             });
 

--- a/TestBangazonAPI/TestEmployeeTraining.cs
+++ b/TestBangazonAPI/TestEmployeeTraining.cs
@@ -1,0 +1,91 @@
+﻿//**********************************************************************************************//
+// This test should run to test the getAll, getSingle, Post, And Put, as well as query additions
+// on the EmployeeTraining Controller.
+// Created By Sydney Wait
+//
+//*********************************************************************************************//
+
+using Newtonsoft.Json;
+using BangazonAPI.Models;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using System.Linq;
+
+namespace TestBangazonAPI
+{
+    public class TestEmployeeTraining
+    {
+
+
+        // Create a new employeeTraining in the db and make sure we get a 200 OK status code back
+
+        public async Task<EmployeeTraining> createEmployeeTraining(HttpClient client)
+        {
+            EmployeeTraining employeeTraining = new EmployeeTraining
+            {
+
+                EmployeeId = 1,
+                TrainingProgramId = 1
+
+            };
+            string employeeTrainingAsJSON = JsonConvert.SerializeObject(employeeTraining);
+
+
+            HttpResponseMessage response = await client.PostAsync(
+                "api/employeeTraining",
+                new StringContent(employeeTrainingAsJSON, Encoding.UTF8, "application/json")
+            );
+
+            response.EnsureSuccessStatusCode();
+
+            string responseBody = await response.Content.ReadAsStringAsync();
+            EmployeeTraining newEmployeeTraining = JsonConvert.DeserializeObject<EmployeeTraining>(responseBody);
+
+            Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+            return newEmployeeTraining;
+
+        }
+
+        // Delete a employeeTraining join table in the database and make sure we get a no content status code back
+        public async Task deleteEmployeeTraining(EmployeeTraining employeeTraining, HttpClient client)
+        {
+            HttpResponseMessage deleteResponse = await client.DeleteAsync($"api/employeeTraining/{employeeTraining.Id}");
+            deleteResponse.EnsureSuccessStatusCode();
+            Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        }
+
+
+
+
+
+        [Fact]
+        public async Task Test_Create_EmployeeTraining()
+        {
+            using (var client = new APIClientProvider().Client)
+            {
+
+                // Create a new EmployeeTraining
+                EmployeeTraining newEmployeeTraining = await createEmployeeTraining(client);
+
+                // Make sure the info checks out
+                Assert.Equal(1, newEmployeeTraining.EmployeeId);
+
+
+
+                // Clean up after ourselves - delete EmployeeTraining!
+                deleteEmployeeTraining(newEmployeeTraining, client);
+            }
+        }
+
+    }
+}
+
+
+
+       


### PR DESCRIPTION
# Description

I refactored the TrainingProgram controller to display training programs even if they do not have any employees assigned to them.  I also added a controller for the join table so employees can be added or removed from a training program.

## Related Ticket(s)
9 (sort of)

## Steps to Test
save and commit on your own branch before checking out to sw-employee-training-refactor and pull down the most recent version.

Run all the tests, including the new addition (TestEmployeeTraining).

Go to Postman and try to post and delete to the endpoint 
https://localhost:5001/api/employeetraining
https://localhost:5001/api/employeetraining/{id}

The object to post should look like 
{
"employeeId": 1,
"trainingProgramId": 2
}


NOTE: GET is not supported.  You will have to look at the sql database to see if it posted or deleted as expected, or just ensure you have a 200 response in postman.

# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
